### PR TITLE
Use chunked hash calculation

### DIFF
--- a/releases.py
+++ b/releases.py
@@ -5,6 +5,32 @@ import json
 import os
 import re
 
+class ChunkedHash():
+    # Calculate hash for chunked data
+    @staticmethod
+    def hash_bytestr_iter(bytesiter, hasher, ashexstr=True):
+        for block in bytesiter:
+            hasher.update(block)
+        return (hasher.hexdigest() if ashexstr else hasher.digest())
+
+    # Read file in blocks/chunks to be memory efficient
+    @staticmethod
+    def file_as_blockiter(afile, blocksize=65536):
+        with afile:
+          block = afile.read(blocksize)
+          while len(block) > 0:
+              yield block
+              block = afile.read(blocksize)
+
+    # Calculate sha256 hash for a file
+    @staticmethod
+    def calculate_sha256(fname):
+        try:
+            return ChunkedHash.hash_bytestr_iter(ChunkedHash.file_as_blockiter(open(fname, "rb")), hashlib.sha256())
+        except:
+            raise
+            return ""
+
 class ReleaseFile():
     def __init__(self, path, url):
         self._path = path
@@ -124,16 +150,12 @@ class ReleaseFile():
                 for i,release in enumerate(sorted(releases)):
                     key = "%s;%s;%s" % (train, build, release)
                     if key not in self.oldhash:
-                      print("Adding: %s" % release)
-                      sha256hash = hashlib.sha256()
-                      with open(os.path.join(path, release), 'rb') as f:
-                          buf = f.read()
-                          sha256hash.update(buf)
-                      file_digest = sha256hash.hexdigest()
-                      file_size = str(os.path.getsize(os.path.join(path, release)))
+                        print("Adding: %s" % release)
+                        file_digest = ChunkedHash().calculate_sha256(os.path.join(path, release))
+                        file_size = str(os.path.getsize(os.path.join(path, release)))
                     else:
-                      file_digest = self.oldhash[key]["sha256"]
-                      file_size = self.oldhash[key]["size"]
+                        file_digest = self.oldhash[key]["sha256"]
+                        file_size = self.oldhash[key]["size"]
 
                     # .tar
                     self.update_json[train]['project'][build]['releases'][i] = {'file': {'name': release}}
@@ -145,16 +167,12 @@ class ReleaseFile():
                     try:
                         key = "%s;%s;%s" % (train, build, image[0])
                         if key not in self.oldhash:
-                          print("Adding: %s" % image[0])
-                          sha256hash = hashlib.sha256()
-                          with open(os.path.join(path, image[0]), 'rb') as f:
-                              buf = f.read()
-                              sha256hash.update(buf)
-                          file_digest = sha256hash.hexdigest()
-                          file_size = str(os.path.getsize(os.path.join(path, image[0])))
+                            print("Adding: %s" % image[0])
+                            file_digest = ChunkedHash().calculate_sha256(os.path.join(path, image[0]))
+                            file_size = str(os.path.getsize(os.path.join(path, image[0])))
                         else:
-                          file_digest = self.oldhash[key]["sha256"]
-                          file_size = self.oldhash[key]["size"]
+                            file_digest = self.oldhash[key]["sha256"]
+                            file_size = self.oldhash[key]["size"]
                         self.update_json[train]['project'][build]['releases'][i]['image'] = {'name': image[0]}
                         self.update_json[train]['project'][build]['releases'][i]['image']['sha256'] = file_digest
                         self.update_json[train]['project'][build]['releases'][i]['image']['size'] = file_size

--- a/releases.py
+++ b/releases.py
@@ -37,11 +37,11 @@ class ReleaseFile():
 
     def UpdateAll(self):
         outfile = os.path.join(self._path, self._output_file)
-        
+
         self.ReadFile(outfile)
-        
+
         self.UpdateFile(self._path, self._url)
-        
+
         self.WriteFile(outfile)
 
     def UpdateCombinedFile(self):
@@ -90,14 +90,14 @@ class ReleaseFile():
             regex = re.compile(r'([0-9]+)\.95\.[0-9]+')
             if regex.search(release):
                 trains.append(str(int(regex.findall(release)[0]) + 1))
-        
+
         trains = list(set(trains))
-        
+
         for i,train in enumerate(trains):
             trains[i] = 'LibreELEC-' + train + '.0'
-            
+
         print(trains)
-        
+
         builds = []
         for release in files:
             regex = re.compile(r'LibreELEC-(.*)-[0-9]')
@@ -115,11 +115,11 @@ class ReleaseFile():
             for build in builds:
                 self.update_json[train]['project'][build] = {'releases': {}}
                 self.update_json[train]['project'][build]['displayName'] = self.display_name[build]
-                releases = [x for x in files if (re.search(major_version[0] + '+.[0-9].[0-9]+', x) or 
-                                                 re.search(str(int(major_version[0]) - 1) + '+.90.[0-9]+', x) or 
-                                                 re.search(str(int(major_version[0]) - 1) + '+.95.[0-9]+', x)) and 
-                                                 re.search(build, x) and 
-                                                 re.search('.tar', x) and not 
+                releases = [x for x in files if (re.search(major_version[0] + '+.[0-9].[0-9]+', x) or
+                                                 re.search(str(int(major_version[0]) - 1) + '+.90.[0-9]+', x) or
+                                                 re.search(str(int(major_version[0]) - 1) + '+.95.[0-9]+', x)) and
+                                                 re.search(build, x) and
+                                                 re.search('.tar', x) and not
                                                  re.search('noobs', x)]
                 for i,release in enumerate(sorted(releases)):
                     key = "%s;%s;%s" % (train, build, release)
@@ -139,8 +139,8 @@ class ReleaseFile():
                     self.update_json[train]['project'][build]['releases'][i] = {'file': {'name': release}}
                     self.update_json[train]['project'][build]['releases'][i]['file']['sha256'] = file_digest
                     self.update_json[train]['project'][build]['releases'][i]['file']['size'] = file_size
-        
-                    # .img.gz            
+
+                    # .img.gz
                     image = [x for x in files if re.match(release.strip('.tar') + '.img.gz', x)]
                     try:
                         key = "%s;%s;%s" % (train, build, image[0])
@@ -192,6 +192,6 @@ if len(sys.argv) < 2:
     print("ERROR: Need to know which project - RPi, RPi2, Generic etc.")
     sys.exit(1)
 '''
-            
+
 with ReleaseFile('/var/www/releases.libreelec.tv/', 'http://releases.libreelec.tv/') as rf:
     rf.UpdateAll()


### PR DESCRIPTION
When calculating the sha256 hash we currently read the entire binary file into memory, which could result in problems when dealing with large image files on memory limited devices.

This change introduces a chunked hash method, which processes the input file in blocks of 64KB. As a bonus, this new method is significantly faster than the read-all-at-once method, presumably as Python doesn't have to repeatedly allocate large chunks of memory to store the file that is to be hashed.

Comparing a directory of 357 Generic tar files (average 225MB each) on the web03 ARM server, the all-at-once and chunked hashing methods calculated identical hashes, with the chunked method being significantly faster:

```
Elapsed Time for 357 files:
Old method: 2620.00 secs, avg = 7.338948 secs
New method: 1641.09 secs, avg = 4.596879 secs
```

I've also included a small change to cleanup some whitespace issues.

