### PR TITLE
Search in subfolders for release images/files

### DIFF
--- a/releases.py
+++ b/releases.py
@@ -47,7 +47,7 @@ DISTRO_NAME = 'LibreELEC'
 
 PRETTYNAME = '^%s-.*-([0-9]+\.[0-9]+\.[0-9]+)' % DISTRO_NAME
 
-PRETTYNAME_NIGHTLY = '^LibreELEC-.*-([0-9]+\.[0-9]+\-.*-[0-9]{8}-[0-9a-z]{7})' % DISTRO_NAME
+PRETTYNAME_NIGHTLY = '^%s-.*-([0-9]+\.[0-9]+\-.*-[0-9]{8}-[0-9a-z]{7})' % DISTRO_NAME
 
 class ChunkedHash():
     # Calculate hash for chunked data
@@ -264,13 +264,13 @@ class ReleaseFile():
         files = []
         images = []
         for (dirpath, dirnames, filenames) in os.walk(path):
+            current_dir = dirpath.lstrip(path + os.sep)
             for f in filenames:
                 if f.startswith('%s-' % DISTRO_NAME):
                     if f.endswith('.tar') and not f.endswith('-noobs.tar'):
-                        files.append(f)
+                        files.append(os.path.join(current_dir, f))
                     elif f.endswith('.img.gz'):
-                        images.append(f)
-            break
+                        images.append(os.path.join(current_dir, f))
 
         # From files, identify all release trains (8.0, 8.0, 8.2, 9.0 etc.)
         releases = []
@@ -291,7 +291,8 @@ class ReleaseFile():
 
         # Create a unique sorted list of builds (eg. RPi2.arm, Generix.x86_64 etc.)
         builds = []
-        for release in files:
+        for f in files:
+            release=os.path.basename(f)
             if self._regex_builds.match(release):
                 builds.append(self._regex_builds.findall(release)[0])
         builds = sorted(list(set(builds)))
@@ -305,7 +306,7 @@ class ReleaseFile():
             self.update_json[train]['project'] = {}
 
             for build in builds:
-                releases = sorted([x for x in files if self.match_version(x, build, train)], key=cmp_to_key(self.custom_sort_release))
+                releases = sorted([x for x in files if self.match_version(os.path.basename(x), build, train)], key=cmp_to_key(self.custom_sort_release))
 
                 entries = {}
                 for i, release in enumerate(releases):


### PR DESCRIPTION
With this change, the release script also searches in subfolder for images and release files. The relative path instead of only filename is added.

Might be a first step for new structure of https://test.libreelec.tv/

Files:
```bash
% tree
.
├── release.py
└── test
    ├── 11.0
    │   └── Rpi
    │       ├── LibreELEC-RPi2.arm-11.0-nightly-20220614-cfd1fd2.img.gz
    │       └── LibreELEC-RPi2.arm-11.0-nightly-20220614-cfd1fd2.tar
    └── releases.json
```

Result `python3 releases.py -i path/test -u http://localhost/`:

```json
{
  "LibreELEC-11.0": {
    "prettyname_regex": "^LibreELEC-.*-([0-9]+\\.[0-9]+\\.[0-9]+)",
    "project": {
      "RPi2.arm": {
        "displayName": "Raspberry Pi 2 and 3",
        "releases": {
          "0": {
            "file": {},
            "image": {
              "name": "11.0/Rpi/LibreELEC-RPi2.arm-11.0-nightly-20220614-cfd1fd2.img.gz",
              "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
              "size": "0"
            }
          },
          "1": {
            "file": {},
            "image": {
              "name": "11.0/Rpi/LibreELEC-RPi2.arm-11.0-nightly-20220614-cfd1fd2.img.gz",
              "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
              "size": "0"
            }
          }
        }
      }
    },
    "url": "http://localhost/"
  }
}
```