### PR TITLE
Rework for new infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,40 @@
 # Description 
-The scripts in the repository are used to generate the releases.json file used in the USB-SD-Creator and in the manual update feature present in LibreELEC 8.0+
+The scripts in the repository are used to generate the releases.json file used in the USB-SD-Creator and in the addon's update feature present in LibreELEC 10.0+.
 
-The script generates a json formatted output with the filenames, file sizes, and sha256 sums.
+The script generates a json formatted output with the filenames, file sizes, sha256 sums, modification timestamp, and the directory subpath the file resides in.
 
 For example
 ```
-{  
-   "LibreELEC-8.0":{  
-      "url":"http://releases.libreelec.tv/",
-      "project":{  
-         "WeTek_Hub.aarch64":{  
-            "displayName":"WeTek Hub",
-            "releases":{  
-               "0":{  
-                  "image":{  
-                     "sha256":"bcc1f74fa1deda0db8d873aefb9d154271698982d0503a6a3170ec0c2bc33a59",
-                     "name":"LibreELEC-WeTek_Hub.aarch64-7.90.005.img.gz",
-                     "size":"116989175"
-                  },
-                  "file":{  
-                     "sha256":"d82ead255190c30c43c3f6bc57962bf5f46863598fd67a31b0e2e5ecb375fbe7",
-                     "name":"LibreELEC-WeTek_Hub.aarch64-7.90.005.tar",
-                     "size":"128993280"
-                  }
-               },
+{
+  "LibreELEC-10.0": {
+    "prettyname_regex": "^LibreELEC-.*-([0-9]+\\.[0-9]+\\-.*-[0-9]{8}-[0-9a-z]{7})",
+    "project": {
+      "RPi2.arm": {
+        "displayName": "Raspberry Pi 2 and 3",
+        "releases": {
+          "0": {
+            "file": {
+              "name": "LibreELEC-RPi2.arm-10.0.2.tar",
+              "sha256": "3c4f6b848f4e5d700d4389fdd08f9a99cfc1a3c8791d9d803584e4197c69cb19",
+              "size": "129945600",
+              "subpath": "10.0/RPi",
+              "timestamp": "2022-03-05 18:17:34"
+            },
+            "image": {
+              "name": "LibreELEC-RPi2.arm-10.0.2.img.gz",
+              "sha256": "9befdc8f42a663e57d7e1e24230fa11354a25cf003ef352c9d3ec576919bea90",
+              "size": "126804594",
+              "subpath": "10.0/RPi",
+              "timestamp": "2022-03-05 18:17:59"
+            }
+          }
+        }
+      }
+    },
+    "url": "https://releases.libreelec.tv/"
+  },
 ```
-For the full output see, http://releases.libreelec.tv/releases.json
+For the full output see, https://releases.libreelec.tv/releases.json
 
 # How to run
 ```

--- a/releases.py
+++ b/releases.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
+# requires python >= 3.9
+
 import os
 import sys
 import re
@@ -42,12 +44,9 @@ VERSIONS = [
            ]
 
 JSON_FILE = 'releases.json'
-
 DISTRO_NAME = 'LibreELEC'
-
 PRETTYNAME = '^%s-.*-([0-9]+\.[0-9]+\.[0-9]+)' % DISTRO_NAME
-
-PRETTYNAME_NIGHTLY = '^LibreELEC-.*-([0-9]+\.[0-9]+\-.*-[0-9]{8}-[0-9a-z]{7})' % DISTRO_NAME
+#PRETTYNAME_NIGHTLY = '^LibreELEC-.*-([0-9]+\.[0-9]+\-.*-[0-9]{8}-[0-9a-z]{7})' % DISTRO_NAME
 
 class ChunkedHash():
     # Calculate hash for chunked data
@@ -79,11 +78,11 @@ class ReleaseFile():
     def __init__(self, args):
         self._json_file = JSON_FILE
 
-        self._indir = args.input.rstrip(os.path.sep)
-        self._url = args.url.rstrip('/')
+        self._indir = args.input.removesuffix(os.path.sep)
+        self._url = args.url.removesuffix('/')
 
         if args.output:
-            self._outdir = args.output.rstrip(os.path.sep)
+            self._outdir = args.output.removesuffix(os.path.sep)
         else:
             self._outdir = self._indir
 

--- a/releases.py
+++ b/releases.py
@@ -201,20 +201,6 @@ class ReleaseFile():
                 return f'{item_maj_min:.1f}'
         return None
 
-    def custom_sort_train(self, a, b):
-        a_items = a.split('-')
-        b_items = b.split('-')
-
-        a_builder = a_items[0]
-        b_builder = b_items[0]
-
-        if (a_builder == b_builder):
-          return (float(a_items[1]) - float(b_items[1]))
-        elif (a_builder < b_builder):
-          return -1
-        elif (a_builder > b_builder):
-          return +1
-
     def get_details(self, path, train, build, file):
         key = f'{train};{build};{file}'
         if key not in self.oldhash:

--- a/releases.py
+++ b/releases.py
@@ -104,72 +104,36 @@ class ReleaseFile():
 
         # nightly image format: {distro}-{proj.device}-{train}-nightly-date-githash{-uboot}.img.gz
         self._regex_nightly_image = re.compile(r'''
-            ^(\w+)          # Distro (alphanumerics)
-            -(\w+[.]\w+)    # Device (alphanumerics.alphanumerics)
-            -(\d+[.]\d+)    # Train (decimals.decimals)
-            -nightly-\d+    # Date (decimals)
-            -[0-9a-fA-F]+   # Git Hash (hexadecimals)
-            (\S*)           # Uboot name with leading '-' (non-whitespace)
-            \.img\.gz''', re.VERBOSE)
-
-        # nightly *-legacy image format: {distro}-{proj-legacy.device}-{train}-nightly-date-githash{-uboot}.img.gz
-        self._regex_nightly_legacy_image = re.compile(r'''
-            ^(\w+)              # Distro (alphanumerics)
-            -(\w+-legacy[.]\w+) # Device (alphanumerics-legacy.alphanumerics)
-            -(\d+[.]\d+)        # Train (decimals.decimals)
-            -nightly-\d+        # Date (decimals)
-            -[0-9a-fA-F]+       # Git Hash (hexadecimals)
-            (\S*)               # Uboot name with leading '-' (non-whitespace)
+            ^(\w+)                   # Distro (alphanumerics)
+            -([0-9a-zA-Z_-]+[.]\w+)  # Device (alphanumerics+'-'.alphanumerics)
+            -(\d+[.]\d+)             # Train (decimals.decimals)
+            -nightly-\d+             # Date (decimals)
+            -[0-9a-fA-F]+            # Git Hash (hexadecimals)
+            (\S*)                    # Uboot name with leading '-' (non-whitespace)
             \.img\.gz''', re.VERBOSE)
 
         # nightly tarball format: {distro}-{proj.device}-{train}-nightly-date-githash{-uboot}.tar
         self._regex_nightly_tarball = re.compile(r'''
-            ^(\w+)          # Distro (alphanumerics)
-            -(\w+[.]\w+)    # Device (alphanumerics.alphanumerics)
-            -(\d+[.]\d+)    # Train (decimals.decimals)
-            -nightly-\d+    # Date (decimals)
-            -[0-9a-fA-F]+   # Git Hash (hexadecimals)
-            (\S*)           # Uboot name with leading '-' (non-whitespace)
-            \.tar''', re.VERBOSE)
-
-        # nightly *-legacy tarball format: {distro}-{proj-legacy.device}-{train}-nightly-date-githash{-uboot}.tar
-        self._regex_nightly_legacy_tarball = re.compile(r'''
-            ^(\w+)              # Distro (alphanumerics)
-            -(\w+-legacy[.]\w+) # Device (alphanumerics-legacy.alphanumerics)
-            -(\d+[.]\d+)        # Train (decimals.decimals)
-            -nightly-\d+        # Date (decimals)
-            -[0-9a-fA-F]+       # Git Hash (hexadecimals)
-            (\S*)               # Uboot name with leading '-' (non-whitespace)
+            ^(\w+)                   # Distro (alphanumerics)
+            -([0-9a-zA-Z_-]+[.]\w+)  # Device (alphanumerics.alphanumerics)
+            -(\d+[.]\d+)             # Train (decimals.decimals)
+            -nightly-\d+             # Date (decimals)
+            -[0-9a-fA-F]+            # Git Hash (hexadecimals)
+            (\S*)                    # Uboot name with leading '-' (non-whitespace)
             \.tar''', re.VERBOSE)
 
         # release image format: {distro}-{proj.device}-{maj.min}.bug{-uboot}.img.gz
         self._regex_release_image = re.compile(r'''
-            ^(\w+)              # Distro (alphanumerics)
-            -(\w+[.]\w+)        # Device (alphanumerics.alphanumerics)
-            -(\d+[.]\d+)[.]\d+  # Train (decimals.decimals)
-            (\S*)               # Uboot name with leading '-' (non-whitespace)
-            \.img\.gz''', re.VERBOSE)
-
-        # release *-legacy image format: {distro}-{proj.device}-{maj.min}.bug{-uboot}.img.gz
-        self._regex_release_legacy_image = re.compile(r'''
-            ^(\w+)              # Distro (alphanumerics)
-            -(\w+-legacy[.]\w+) # Device (alphanumerics-legacy.alphanumerics)
-            -(\d+[.]\d+)[.]\d+  # Train (decimals.decimals)
-            (\S*)               # Uboot name with leading '-' (non-whitespace)
+            ^(\w+)                   # Distro (alphanumerics)
+            -([0-9a-zA-Z_-]+[.]\w+)  # Device (alphanumerics.alphanumerics)
+            -(\d+[.]\d+)[.]\d+       # Train (decimals.decimals)
+            (\S*)                    # Uboot name with leading '-' (non-whitespace)
             \.img\.gz''', re.VERBOSE)
 
         # release tarball format: {distro}-{proj.device}-{maj.min}.bug.tar
         self._regex_release_tarball = re.compile(r'''
             ^(\w+)              # Distro (alphanumerics)
-            -(\w+[.]\w+)        # Device (alphanumerics.alphanumerics)
-            -(\d+[.]\d+)[.]\d+  # Train (decimals.decimals.decimals)
-            (\S*)               # Uboot name with leading '-' (non-whitespace)
-            \.tar''', re.VERBOSE)
-
-        # release *-legacy tarball format: {distro}-{proj.device}-{maj.min}.bug.tar
-        self._regex_release_legacy_tarball = re.compile(r'''
-            ^(\w+)              # Distro (alphanumerics)
-            -(\w+-legacy[.]\w+) # Device (alphanumerics-legacy.alphanumerics)
+            -([0-9a-zA-Z_-]+[.]\w+)        # Device (alphanumerics+'-'.alphanumerics)
             -(\d+[.]\d+)[.]\d+  # Train (decimals.decimals.decimals)
             (\S*)               # Uboot name with leading '-' (non-whitespace)
             \.tar''', re.VERBOSE)
@@ -293,67 +257,43 @@ class ReleaseFile():
             for f in filenames:
                 if f.startswith(f'{DISTRO_NAME}-'):
                     if f.endswith('.tar') and not f.endswith('-noobs.tar'):
+                        # nightly tarballs
                         if 'nightly' in f:
                             if not args.all and datetime.fromtimestamp(os.path.getmtime(os.path.join(dirpath, f))) < nightly_retention:
                                 if args.verbose:
                                     print(f'Old nightly: {f}')
                                 continue
-                            if '-legacy' in f:
-                                try:
-                                    parsed_fname = self._regex_nightly_legacy_tarball.search(f)
-                                except Exception:
-                                    print(f'Failed to parse filename: {f}')
-                                    continue
-                            else:
-                                try:
-                                    parsed_fname = self._regex_nightly_tarball.search(f)
-                                except Exception:
-                                    print(f'Failed to parse filename: {f}')
-                                    continue
+                            try:
+                                parsed_fname = self._regex_nightly_tarball.search(f)
+                            except Exception:
+                                print(f'Failed to parse filename: {f}')
+                                continue
+                        # release tarballs
                         else:
-                            if '-legacy' in f:
-                                try:
-                                    parsed_fname = self._regex_release_legacy_tarball.search(f)
-                                except Exception:
-                                    print(f'Failed to parse filename: {f}')
-                                    continue
-                            else:
-                                try:
-                                    parsed_fname = self._regex_release_tarball.search(f)
-                                except Exception:
-                                    print(f'Failed to parse filename: {f}')
-                                    continue
+                            try:
+                                parsed_fname = self._regex_release_tarball.search(f)
+                            except Exception:
+                                print(f'Failed to parse filename: {f}')
+                                continue
                     elif f.endswith('.img.gz'):
+                        # nightly images
                         if 'nightly' in f:
                             if not args.all and datetime.fromtimestamp(os.path.getmtime(os.path.join(dirpath, f))) < nightly_retention:
                                 if args.verbose:
                                     print(f'Old nightly: {f}')
                                 continue
-                            if '-legacy' in f:
-                                try:
-                                    parsed_fname = self._regex_nightly_legacy_image.search(f)
-                                except Exception:
-                                    print(f'Failed to parse filename: {f}')
-                                    continue
-                            else:
-                                try:
-                                    parsed_fname = self._regex_nightly_image.search(f)
-                                except Exception:
-                                    print(f'Failed to parse filename: {f}')
-                                    continue
+                            try:
+                                parsed_fname = self._regex_nightly_image.search(f)
+                            except Exception:
+                                print(f'Failed to parse filename: {f}')
+                                continue
                         else:
-                            if '-legacy' in f:
-                                try:
-                                    parsed_fname = self.regex_release_legacy_image.search(f)
-                                except Exception:
-                                    print(f'Failed to parse filename: {f}')
-                                    continue
-                            else:
-                                try:
-                                    parsed_fname = self._regex_release_image.search(f)
-                                except Exception:
-                                    print(f'Failed to parse filename: {f}')
-                                    continue
+                        # release images
+                            try:
+                                parsed_fname = self._regex_release_image.search(f)
+                            except Exception:
+                                print(f'Failed to parse filename: {f}')
+                                continue
                     else:
                         if args.verbose:
                             print(f'Ignored file: {f}')

--- a/releases.py
+++ b/releases.py
@@ -71,7 +71,7 @@ class ChunkedHash():
     def calculate_sha256(fname):
         try:
             return ChunkedHash.hash_bytestr_iter(ChunkedHash.file_as_blockiter(open(fname, 'rb')), hashlib.sha256())
-        except:
+        except Exception:
             raise
             return ''
 
@@ -242,7 +242,7 @@ class ReleaseFile():
 
         # Walk top level source directory, selecting files for subsequent processing.
         #
-        # We're only interested in 'LibreELEC-.*.tar' files, and not '.*-noobs.tar' files.
+        # We're interested in 'LibreELEC-.*.(tar|img.gz)' files, but not '.*-noobs.tar' files.
         list_of_files = []
         releases = []
         builds = []
@@ -257,26 +257,26 @@ class ReleaseFile():
                         if 'nightly' in f:
                             try:
                                 parsed_fname = self._regex_nightly_tarball.search(f)
-                            except:
+                            except Exception:
                                 print(f'Failed to parse filename: {f}')
                                 continue
                         else:
                             try:
                                 parsed_fname = self._regex_release_tarball.search(f)
-                            except:
+                            except Exception:
                                 print(f'Failed to parse filename: {f}')
                                 continue
                     elif f.endswith('.img.gz'):
                         if 'nightly' in f:
                             try:
                                 parsed_fname = self._regex_nightly_image.search(f)
-                            except:
+                            except Exception:
                                 print(f'Failed to parse filename: {f}')
                                 continue
                         else:
                             try:
                                 parsed_fname = self._regex_release_image.search(f)
-                            except:
+                            except Exception:
                                 print(f'Failed to parse filename: {f}')
                                 continue
                     else:

--- a/releases.py
+++ b/releases.py
@@ -147,6 +147,7 @@ class ReleaseFile():
                              'Dragonboard.arm': 'Qualcomm Dragonboard',
                              'FORMAT.any': 'Tools',
                              'Generic.x86_64': 'Generic AMD/Intel/NVIDIA (x86_64)',
+                             'Generic-legacy.x86_64': 'Generic AMD/Intel/NVIDIA on X11 (x86_64)',
                              'H3.arm': 'Allwinner H3',
                              'H5.arm': 'Allwinner H5',
                              'H6.arm': 'Allwinner H6',

--- a/releases.py
+++ b/releases.py
@@ -286,6 +286,10 @@ class ReleaseFile():
         releases = []
         builds = []
         for (dirpath, dirnames, filenames) in os.walk(path):
+            if 'archive' in dirpath or 'upload' in dirpath:
+                if args.verbose:
+                    print(f'Skipping directory: {dirpath}')
+                continue
             for f in filenames:
                 if f.startswith(f'{DISTRO_NAME}-'):
                     if 'nightly' in f:

--- a/releases.py
+++ b/releases.py
@@ -434,6 +434,8 @@ class ReleaseFile():
                                         entry['image'] = {'name': image_file[0], 'sha256': file_digest, 'size': file_size, 'timestamp': file_timestamp, 'subpath': image_file[4].removeprefix(f'{self._indir}/')}
                                         list_of_files.remove(image_file)
                                         list_of_filenames.remove(image_file[0])
+#                            else:
+#                                entry['image'] = {'name': '', 'sha256': '', 'size': '', 'timestamp': '', 'subpath': ''}
                         # *-{uboot}.img.gz
                         elif release_file[3]:
                             uboot = []
@@ -464,6 +466,8 @@ class ReleaseFile():
                                         entry['file'] = {'name': tarball_file[0], 'sha256': file_digest, 'size': file_size, 'timestamp': file_timestamp, 'subpath': tarball_file[4].removeprefix(f'{self._indir}/')}
                                         list_of_files.remove(tarball_file)
                                         list_of_filenames.remove(tarball_file[0])
+#                            else:
+#                                entry['file'] = {'name': '', 'sha256': '', 'size': '', 'timestamp': '', 'subpath': ''}
 
                         entries[entry_position] = entry
 

--- a/releases.py
+++ b/releases.py
@@ -213,7 +213,15 @@ class ReleaseFile():
         key = f'{train};{build};{file}'
         if key not in self.oldhash:
             print(f'Adding: {file} to {train} train')
-            file_digest = ChunkedHash().calculate_sha256(os.path.join(path, file))
+            # Use .sha256 file's checksum if present
+            if os.path.exists(os.path.join(path, f'{file}.sha256')):
+                if args.verbose:
+                    print(f'  Using sha256sum from: {file}.sha256')
+                with open(os.path.join(path, f'{file}.sha256'), 'r') as f:
+                    digest_contents = f.read()
+                file_digest = digest_contents.split(' ')[0]
+            else:
+                file_digest = ChunkedHash().calculate_sha256(os.path.join(path, file))
             file_size = str(os.path.getsize(os.path.join(path, file)))
             file_timestamp = datetime.fromtimestamp(os.path.getmtime(os.path.join(path,file))).isoformat(sep=' ', timespec='seconds')
         else:

--- a/releases.py
+++ b/releases.py
@@ -219,10 +219,7 @@ class ReleaseFile():
         else:
             file_digest = self.oldhash[key]['sha256']
             file_size = self.oldhash[key]['size']
-            try:
-                file_timestamp = self.oldhash[key]['timestamp']
-            except:
-                file_timestamp = datetime.fromtimestamp(os.path.getmtime(os.path.join(path,file))).isoformat(sep=' ', timespec='seconds')
+            file_timestamp = self.oldhash[key]['timestamp']
 
         return (file_digest, file_size, file_timestamp)
 
@@ -237,8 +234,7 @@ class ReleaseFile():
 
         # Walk top level source directory, selecting files for subsequent processing.
         #
-        # We're only interested in 'LibreELEC-.*.tar' files, and not interested
-        # in '.*-noobs.tar' files.
+        # We're only interested in 'LibreELEC-.*.tar' files, and not '.*-noobs.tar' files.
         list_of_files = []
         releases = []
         builds = []
@@ -377,22 +373,34 @@ class ReleaseFile():
             try:
                 with open(self._infile, 'r') as f:
                     oldjson = json.loads(f.read())
-                    for train in oldjson:
-                        for build in oldjson[train]['project']:
-                            for release in oldjson[train]['project'][build]['releases']:
-                                r = oldjson[train]['project'][build]['releases'][release]['file']
-                                self.oldhash[f'{train};{build};{r["name"]}'] = {'sha256': r['sha256'], 'size': r['size']}
-                                try:
-                                    i = oldjson[train]['project'][build]['releases'][release]['image']
-                                    self.oldhash[f'{train};{build};{i["name"]}'] = {'sha256': i['sha256'], 'size': i['size']}
-                                except:
-                                    pass
-                                try:
-                                    for i in oldjson[train]['project'][build]['releases'][release]['uboot']:
-                                        self.oldhash[f'{train};{build};{i["name"]}'] = {'sha256': i['sha256'], 'size': i['size']}
-                                except:
-                                    pass
-            except:
+                    if args.verbose:
+                        print(f'Read old json: {self._infile}')
+
+                for train in oldjson:
+                    for build in oldjson[train]['project']:
+                        for release in oldjson[train]['project'][build]['releases']:
+                            try:
+                                data = oldjson[train]['project'][build]['releases'][release]['file']
+                                if args.verbose:
+                                    print(f'Found old json entry for: {data["name"]}')
+                                self.oldhash[f'{train};{build};{data["name"]}'] = {'sha256': data['sha256'], 'size': data['size'], 'timestamp': data['timestamp']}
+                            except KeyError:
+                                pass
+                            try:
+                                data = oldjson[train]['project'][build]['releases'][release]['image']
+                                if args.verbose:
+                                    print(f'Found old json entry for: {data["name"]}')
+                                self.oldhash[f'{train};{build};{data["name"]}'] = {'sha256': data['sha256'], 'size': data['size'], 'timestamp': data['timestamp']}
+                            except KeyError:
+                                pass
+                            try:
+                                data = oldjson[train]['project'][build]['releases'][release]['uboot']
+                                if args.verbose:
+                                    print(f'Found old json entry for: {data["name"]}')
+                                self.oldhash[f'{train};{build};{data["name"]}'] = {'sha256': data['sha256'], 'size': data['size'], 'timestamp': data['timestamp']}
+                            except KeyError:
+                                pass
+            except Exception:
                 self.oldhash = {}
 
     # Write a new file

--- a/releases.py
+++ b/releases.py
@@ -228,6 +228,11 @@ class ReleaseFile():
         self.WriteFile()
 
     def UpdateFile(self):
+
+        # used in sorting file list; field 6 of list element is timestamp
+        def get_timestamp(data):
+            return data[6]
+
         path = self._indir
         url = f'{self._url}/'
 
@@ -309,6 +314,9 @@ class ReleaseFile():
                     if args.verbose:
                         print(f'Ignored file: {f}')
                     continue
+
+        # Sort file list by timestamp
+        list_of_files.sort(key=get_timestamp)
 
         # Sort list of release trains (8.0, 8.2, 9.0 etc.)
         trains = []


### PR DESCRIPTION
This is a rewrite of most of releases.py in order to not have to care whether the files it's adding to the json are *.tar or *.img.gz, as well as accommodate files located in sub-directories. Other changes:

- Files located in `/archive/` or `/upload/` will be ignored (if found anywhere in the path);
- By default, only nightly files modified (created) in the last 10 days will be added to the json. This is to keep the size of the json file down with the amount of nightly images being built and retained. Numbers of days configured by variable. This may be overridden by adding `--all` to the command line;
- If given a matching .sha256 file, get the sum from that instead of recalculating it;
- Adds a timestamp field equal to the file's modification time (needed for delaying automatic updates later);
- Adds a subpath field equal to the sub-directory where the file is located (download url = URL + subpath + filename)
- Every `try...except` should have the exception qualified in some way. This is to let sys.exit() work;
- `--verbose` provides more information;
- Requires Python >=3.9 to run; and
- Deletes most all code not still in use after these changes (remaining stuff is commented).

The file format (not counting the additional fields mentioned above) should be the same as what was produced for previous infrastructure, with one intentional change that blank `image: {}` entries are not generated (I don't know a reason for them, but commented code is written to produce it if needed).

Last known issue is that it can get confused when multiple builds for 1 device happen on the same day (order is at the mercy of the alphabetical order of the githashes when that happens). Solution is probably a more complicated sorting function to assemble the grand list of files in the desired order. Release builds should be unaffected.

Thanks @CvH for assistance with testing.