### PR TITLE
Make compatible with stable release infra too

### DIFF
--- a/releases.py
+++ b/releases.py
@@ -119,7 +119,7 @@ class ReleaseFile():
         self._regex_release_image = re.compile(r'''
             ^(\w+)                   # Distro (alphanumerics)
             -([0-9a-zA-Z_-]+[.]\w+)  # Device (alphanumerics.alphanumerics)
-            -(\d+[.]\d+)[.]\d+       # Train (decimals.decimals).decimals
+            -(\d+\.\d+)\.\d+(\.\d+)? # Train (decimals.decimals).decimals(.decimals(optional))
             (\S*)                    # Uboot name with leading '-' (non-whitespace)
             (\.img\.gz|\.tar)''', re.VERBOSE)
 
@@ -275,10 +275,10 @@ class ReleaseFile():
                     fname_train = parsed_fname.group(3)
                     if 'nightly' in f:
                         fname_githash = parsed_fname.group(4)
-                        fname_uboot = self.lchop(parsed_fname.group(5), '-')
                     else:
+                        #parsed_fname.group(4) would be the 4th version number
                         fname_githash = None
-                        fname_uboot = self.lchop(parsed_fname.group(4), '-')
+                    fname_uboot = self.lchop(parsed_fname.group(5), '-')
                     fname_timestamp = datetime.fromtimestamp(os.path.getmtime(os.path.join(dirpath,f))).isoformat(sep=' ', timespec='seconds')
 
                     distro_train = f'{fname_distro}-{self.get_train_major_minor(fname_train)}'

--- a/releases.py
+++ b/releases.py
@@ -420,10 +420,12 @@ class ReleaseFile():
                         base_filename = self.rchop(base_filename, '.img.gz')
 
                         (file_digest, file_size) = self.get_details(release_file[5], train, build, release_file[0])
+                        file_subpath = self.lchop(release_file[5], self._indir)
+                        file_subpath = self.lchop(file_subpath, '/')
 
                         # *.tar
                         if release_file[0].endswith('.tar'):
-                            entry['file'] = {'name': release_file[0], 'sha256': file_digest, 'size': file_size, 'timestamp': release_file[6], 'subpath': self.lchop(release_file[5], f'{self._indir}/')}
+                            entry['file'] = {'name': release_file[0], 'sha256': file_digest, 'size': file_size, 'timestamp': release_file[6], 'subpath': file_subpath}
                             list_of_files.remove(release_file)
                             list_of_filenames.remove(release_file[0])
                             # check for image files with same name so they may be added
@@ -431,7 +433,9 @@ class ReleaseFile():
                                 for image_file in list(list_of_files):
                                     if f'{base_filename}.img.gz' == image_file[0]:
                                         (file_digest, file_size) = self.get_details(image_file[5], train, build, image_file[0])
-                                        entry['image'] = {'name': image_file[0], 'sha256': file_digest, 'size': file_size, 'timestamp': image_file[6], 'subpath': self.lchop(image_file[5], f'{self._indir}/')}
+                                        file_subpath = self.lchop(image_file[5], self._indir)
+                                        file_subpath = self.lchop(file_subpath, '/')
+                                        entry['image'] = {'name': image_file[0], 'sha256': file_digest, 'size': file_size, 'timestamp': image_file[6], 'subpath': file_subpath}
                                         list_of_files.remove(image_file)
                                         list_of_filenames.remove(image_file[0])
 #                            else:
@@ -439,7 +443,7 @@ class ReleaseFile():
                         # *-{uboot}.img.gz
                         elif release_file[4]:
                             uboot = []
-                            uboot.append({'name': release_file[0], 'sha256': file_digest, 'size': file_size, 'timestamp': release_file[6], 'subpath': self.lchop(release_file[5], f'{self._indir}/')})
+                            uboot.append({'name': release_file[0], 'sha256': file_digest, 'size': file_size, 'timestamp': release_file[6], 'subpath': file_subpath})
                             list_of_files.remove(release_file)
                             list_of_filenames.remove(release_file[0])
                             # check for similar uboot releases
@@ -448,14 +452,16 @@ class ReleaseFile():
                                     for image_file in list(list_of_files):
                                         if image_file[0].startswith(self.rchop(base_filename, f'-{release_file[4]}')):
                                             (file_digest, file_size) = self.get_details(image_file[5], train, build, image_file[0])
-                                            uboot.append({'name': image_file[0], 'sha256': file_digest, 'size': file_size, 'timestamp': image_file[6], 'subpath': self.lchop(image_file[5], f'{self._indir}/')})
+                                            file_subpath = self.lchop(image_file[5], self._indir)
+                                            file_subpath = self.lchop(file_subpath, '/')
+                                            uboot.append({'name': image_file[0], 'sha256': file_digest, 'size': file_size, 'timestamp': image_file[6], 'subpath': file_subpath})
                                             list_of_files.remove(image_file)
                                             list_of_filenames.remove(image_file[0])
 
                             entry['uboot'] = uboot
                         # *.img.gz
                         elif release_file[0].endswith('.img.gz'):
-                            entry['image'] = {'name': release_file[0], 'sha256': file_digest, 'size': file_size, 'timestamp': release_file[6], 'subpath': self.lchop(release_file[5], f'{self._indir}/')}
+                            entry['image'] = {'name': release_file[0], 'sha256': file_digest, 'size': file_size, 'timestamp': release_file[6], 'subpath': file_subpath}
                             list_of_files.remove(release_file)
                             list_of_filenames.remove(release_file[0])
                             # check for tarball files with same name so they may be added
@@ -463,7 +469,9 @@ class ReleaseFile():
                                 for tarball_file in list(list_of_files):
                                     if f'{base_filename}.tar' == tarball_file[0]:
                                         (file_digest, file_size) = self.get_details(tarball_file[5], train, build, tarball_file[0])
-                                        entry['file'] = {'name': tarball_file[0], 'sha256': file_digest, 'size': file_size, 'timestamp': tarball_file[6], 'subpath': self.lchop(tarball_file[5], f'{self._indir}/')}
+                                        file_subpath = self.lchop(tarball_file[5], self._indir)
+                                        file_subpath = self.lchop(file_subpath, '/')
+                                        entry['file'] = {'name': tarball_file[0], 'sha256': file_digest, 'size': file_size, 'timestamp': tarball_file[6], 'subpath': file_subpath}
                                         list_of_files.remove(tarball_file)
                                         list_of_filenames.remove(tarball_file[0])
 #                            else:

--- a/releases.py
+++ b/releases.py
@@ -5,15 +5,14 @@
 
 # requires python >= 3.8
 
-import os
-import sys
-import re
 import argparse
 import hashlib
 import json
-from datetime import datetime
-from functools import cmp_to_key
+import os
+import re
 from collections import OrderedDict
+from datetime import datetime
+
 
 # x.80.z        => (x+1).0.z  (pre-alpha, use next major train)
 # x.90.z        => (x+1).0.z  (alpha, use next major train)

--- a/releases.py
+++ b/releases.py
@@ -260,7 +260,27 @@ class ReleaseFile():
                     print(f'Skipping directory: {dirpath}')
                 continue
             for f in filenames:
-                if f.startswith(f'{DISTRO_NAME}-'):
+                # hardcode the image used to wipe sd cards by the usb-sd tool
+                if f.startswith('LibreELEC-FORMAT.any-1.0.0-erase-usb-sd'):
+                    fname_device = 'FORMAT.any'
+                    fname_githash = None
+                    fname_uboot = ''
+                    fname_timestamp = '1970-01-01 00:00:00'
+                    distro_train = 'LibreELEC-1.0'
+
+                    if distro_train not in releases:
+                        if args.verbose:
+                            print(f'Adding to releases: {distro_train}')
+                        releases.append(distro_train)
+                    if fname_device not in builds:
+                        if args.verbose:
+                            print(f'Adding to builds: {fname_device}')
+                        builds.append(fname_device)
+
+                    list_of_files.append([f, distro_train, fname_device, fname_githash, fname_uboot, dirpath, fname_timestamp])
+                    list_of_filenames.append(f)
+
+                elif f.startswith(f'{DISTRO_NAME}-'):
                     if f.endswith('.tar') and not f.endswith('-noobs.tar'):
                         # nightly tarballs
                         if 'nightly' in f:

--- a/releases.py
+++ b/releases.py
@@ -208,13 +208,6 @@ class ReleaseFile():
         self.WriteFile()
 
     def UpdateFile(self):
-
-        # used in sorting file list; field 6 of list element is timestamp, 7 is filetype
-        def get_timestamp(data):
-            return data[6]
-        def get_filetype(data):
-            return data[7]
-
         path = self._indir
         url = f'{self._url}/'
 
@@ -301,8 +294,8 @@ class ReleaseFile():
                         print(f'Ignored file: {f}')
                     continue
 
-        # Sort file list by timestamp then all tarballs before images
-        list_of_files.sort(key=get_timestamp)
+        # Sort file list by timestamp
+        list_of_files.sort(key=lambda data: data[6])
 
         # Sort list of release trains (8.0, 8.2, 9.0 etc.)
         trains = []


### PR DESCRIPTION
This replaces removeprefix and removesuffix with self-defined lchop and rchop, respectively. They're features of python >=3.9.  This is intended to make the script compatible with python 3.8 (probably >= 3.6).