### PR TITLE
releases.py: add smoketest duration to delay automatic updates

### DIFF
--- a/releases.py
+++ b/releases.py
@@ -50,6 +50,7 @@ VERSIONS = [
 BUILDS_PER_DEVICE=10
 JSON_FILE = 'releases.json'
 DISTRO_NAME = 'LibreELEC'
+CANARY_PERIOD = 21 # Days
 PRETTYNAME = f'^{DISTRO_NAME}-.*-([0-9]+\.[0-9]+\.[0-9]+)'
 #PRETTYNAME_NIGHTLY = f'^{DISTRO_NAME}-.*-([0-9]+\.[0-9]+\-.*-[0-9]{8}-[0-9a-z]{7})'
 
@@ -358,7 +359,7 @@ class ReleaseFile():
 
         # Add train data to json
         for train in trains:
-            self.update_json[train] = {'url': url}
+            self.update_json[train] = {'canary': CANARY_PERIOD, 'url': url}
             self.update_json[train]['prettyname_regex'] = self._prettyname
             self.update_json[train]['project'] = {}
 


### PR DESCRIPTION
This adds SMOKETEST_DURATION as a per release branch (LE9, LE10, LE11...) entry. It's set in days and controls how long an image's release is delayed before the update system considers it ready for automatic upgrades.

I still need to edit the client side.