### PR TITLE
prune-archive.py: remove companion .sha256 when purging .img.gz

### DIFF
--- a/prune-archive.py
+++ b/prune-archive.py
@@ -178,6 +178,9 @@ class ManageArchive():
                 # delete if requested
                 if args.delete and os.path.isfile(f[0]):
                     os.remove(f[0])
+                    # remove companion checksum if present
+                    if os.path.isfile(f'{f[0]}.sha256'):
+                        os.remove(f'{f[0]}.sha256')
             if args.verbose:
                 print(f'Total size of purged files: {purge_filesize/(1024**2)}MiB')
         else:


### PR DESCRIPTION
When pruning an old nightly image, the script removed the .img.gz but left its .sha256 checksum orphaned in the archive. Remove the companion checksum alongside the image so the tree stays consistent and no stale checksums accumulate.